### PR TITLE
UPDATE index.bs - fix broken formatting of dt-declaredunit-json

### DIFF
--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1093,7 +1093,7 @@ DeclaredUnit is the enumeration of accepted declared units with values
 </dl>
 
 
-### JSON Representation ### #{#dt-declaredunit-json}
+### JSON Representation ### {#dt-declaredunit-json}
 
 The value of each {{DeclaredUnit}} MUST be encoded as a JSON String.
 


### PR DESCRIPTION
Fixed this rendering error.

![image](https://user-images.githubusercontent.com/18162779/222952702-3476f63d-39cf-46a0-97dd-0cab1a35ec01.png)


```
The following changes since commit 40ab34928beea703a4797cfb4eea9fbd335ea76e:

  docs(spec v2)!: Release v2.0.0 of tech specs (2023-02-21 13:25:03 +0100)

are available in the Git repository at:

  git@github.com:JohnVonNeumann/data-exchange-protocol.git fix-formatting-error-in-declaredunit-json

for you to fetch changes up to 333709bc6a900771f206a28e195ed18e0a5507e0:

  UPDATE index.bs - fix broken formatting of dt-declaredunit-json (2023-03-05 20:26:34 +1100)

----------------------------------------------------------------
JohnVonNeumann (1):
      UPDATE index.bs - fix broken formatting of dt-declaredunit-json

 spec/v2/index.bs | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/spec/v2/index.bs b/spec/v2/index.bs
index c7a8e69..faf1181 100644
--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1093,7 +1093,7 @@ DeclaredUnit is the enumeration of accepted declared units with values
 </dl>
 
 
-### JSON Representation ### #{#dt-declaredunit-json}
+### JSON Representation ### {#dt-declaredunit-json}
 
 The value of each {{DeclaredUnit}} MUST be encoded as a JSON String.
 
@@ -2294,4 +2294,4 @@ The following changes have been applied for version 1.0.1
     "publisher": "WBCSD"
   }
 }
-</pre>
\ No newline at end of file
+</pre>

```