### PR TITLE
UPDATE index.bs - make providerName attribute optional, as per pf functional spec

### DIFF
--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -789,7 +789,7 @@ The following properties are defined for data type <{Assurance}>:
       <tr>
         <td><dfn>providerName</dfn>
         <td>String
-        <td>M
+        <td>O
         <td>The non-empty name of the independent third party engaged to undertake the assurance.
       <tr>
         <td><dfn>completedAt</dfn> : [=DateTime=]


### PR DESCRIPTION
Page 66 of the Pathfinder Framework Specification states that the providerName field (Data Attribute: Assurance provider), is marked "Mandatory: No", I believe that this is due to the description of the field being:

_"The name of the independent third party engaged to undertake the assurance."_

This would align behaviour with that of the "Data Attribute: Assurance", which asks for a boolean "stating whether the PCF has been assured in line with Pathfinder Framework requirements". This is the only mandatory field.

The technical spec should be marked as a non-mandatory in order to be consistent with the `5.3.7 Provider` guidance on `Page 50`:

_When the reporting company also performs the assurance, this is known as first-party assurance. When a party other than the reporting company performs the assurance, this is known as third-party assurance._

Given that the short-term timeline is for coverage at the corporate level, most Assurances will be first-party assurances, not satisfying the requirements for the "Assurance Provider" data attribute of "independent third party".

