### PR TITLE
Bring assurance to parity with pf framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For this, we use an ADR-inspired process.
 
 To make a meaningful contribution:
 
-1. Create an ADR proposal in the [decisions/log](decisions/log/) with status `In Progress`
+1. Create an ADR proposal in the [decisions/log](decisions/log) with status `In Progress`
     1. If possible, already create the changes to the technical specification text as well (see above)
 2. Create a Pull Request with the ADR proposal and optionally the specification changes
 3. Once there is consensus on the ADR proposal, the ADR proposal is merged into the `main` branch
@@ -24,4 +24,4 @@ To make a meaningful contribution:
 
 ## History of decisions
 
-Accepted decisions are stored in the directory [decisions/log](decisions/log/) under branch `main`.
+Accepted decisions are stored in the directory [decisions/log](decisions/log) under branch `main`.

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -785,7 +785,6 @@ The following properties are defined for data type <{Assurance}>:
           - `reasonable` for reasonable assurance
 
           This property MAY be undefined or marked as “n/a” if no assurance has taken place.
-
       <tr>
         <td><dfn>boundary</dfn>
         <td>String

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -827,7 +827,7 @@ The following properties are defined for data type <{Assurance}>:
         <td>
           Any additional comments that will clarify the interpretation of the assurance.
 
-          This value of this property MAY be the empty string.
+          This value of this property MAY be an empty string.
     </table>
   <figcaption>Properties of data type Assurance</figcaption>
 </figure>

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -798,8 +798,8 @@ The following properties are defined for data type <{Assurance}>:
       <tr>
         <td><dfn>providerName</dfn>
         <td>String
-        <td>M
-        <td>The non-empty name of the independent third party engaged to undertake the assurance.
+        <td>O
+        <td>The name of the independent third party engaged to undertake the assurance.
       <tr>
         <td><dfn>completedAt</dfn> : [=DateTime=]
         <td>String

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -796,12 +796,12 @@ The following properties are defined for data type <{Assurance}>:
 
           This property MAY be undefined or marked as “n/a” if no assurance has taken place.
       <tr>
-        <td><dfn>providerName</dfn>
+        <td><dfn>provider</dfn>
         <td>String
         <td>O
         <td>The name of the independent third party engaged to undertake the assurance.
       <tr>
-        <td><dfn>completedAt</dfn> : [=DateTime=]
+        <td><dfn>completionDate</dfn> : [=DateTime=]
         <td>String
         <td>O
         <td>The date at which the assurance was completed. See data type [=DateTime=] for details.

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -736,6 +736,15 @@ The following properties are defined for data type <{DataQualityIndicators}>:
 
 Data type `Assurance` contains the assurance in conformance with [=Pathfinder Framework=] chapter 5 and appendix B.
 
+In instances where a property has the following instruction `This property MAY be undefined or marked as “n/a” if no
+assurance has taken place.`, the Pathfinder Framework dictates that:
+
+    While first-party quality controls and plausibility checks are encouraged, they do not suffice to fulfill the
+    assurance requirements of this guidance.
+
+As a result of this guidance, the `assurance` property cannot be marked as True, so these attributes are not required.
+
+
 The following properties are defined for data type <{Assurance}>:
 
 <figure id="pf-assurance-properties-table" dfn-type="element-attr" dfn-for="Assurance">
@@ -765,7 +774,7 @@ The following properties are defined for data type <{Assurance}>:
           - `PCF system` for PCF System
           - `product level` for product level
 
-          This property MAY be undefined only if the kind of assurance was not performed.
+          This property MAY be undefined or marked as “n/a” if no assurance has taken place.
       <tr>
         <td><dfn>level</dfn>
         <td>String
@@ -775,7 +784,7 @@ The following properties are defined for data type <{Assurance}>:
           - `limited` for limited assurance
           - `reasonable` for reasonable assurance
 
-          This property MAY be undefined only if the kind of assurance was not performed.
+          This property MAY be undefined or marked as “n/a” if no assurance has taken place.
 
       <tr>
         <td><dfn>boundary</dfn>
@@ -785,7 +794,7 @@ The following properties are defined for data type <{Assurance}>:
           - `Gate-to-Gate` for Gate-to-Gate
           - `Cradle-to-Gate` for Cradle-to-Gate.
 
-          This property MAY be undefined only if the kind of assurance was not performed.
+          This property MAY be undefined or marked as “n/a” if no assurance has taken place.
       <tr>
         <td><dfn>providerName</dfn>
         <td>String

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -806,11 +806,20 @@ The following properties are defined for data type <{Assurance}>:
         <td>O
         <td>The date at which the assurance was completed. See data type [=DateTime=] for details.
       <tr>
-        <td><dfn>standardName</dfn>
+        <td><dfn>standard</dfn>
         <td>String
         <td>O
         <td>
-          Name of the standard against which the PCF was assured.
+          Standard(s) against which the PCF was assured.
+      <tr>
+        <td><dfn>statement</dfn>
+        <td>String
+        <td>O
+        <td>
+          A reference to the assurance statement that is used to prove
+          the assurance of the PCF. This can be a PDF attachment or a
+          digital signature. The technical specifications specify details on
+          company identification and digital signature verification.
       <tr>
         <td><dfn>comments</dfn>
         <td>String


### PR DESCRIPTION
I've been writing code for the Assurance datatype on my implementation, found some deltas between the tech spec and the framework, attempted to fix with this PR.