### PR TITLE
fix(spec v2): fix definitions of CarbonFootprint properties `primaryDataShare` and `dqi`

### DIFF
--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -2230,8 +2230,8 @@ path: LICENSE.md
 
 Summary of changes:
 
-1. a definition fix on the definedness for properties <{CarbonFootprint/primaryDataShare}> and <{CarbonFootprint/dqi}>: 
-    previously, they were defined in a mutual-exclusive fashion (either one must be defined but *NOT* both) while the Pathfinder Framework Version 2.0 defines them as follows (Section 4.2.1, Page 39):
+1. definition fixes to properties <{CarbonFootprint/primaryDataShare}> and <{CarbonFootprint/dqi}> to resolve a discrepancy with the latest version of the Pathfinder Framework:
+    previously, the 2 properties were defined in a mutually-exclusive fashion (either one must be defined but *NOT* both) whereas the Pathfinder Framework Version 2.0 defines them as follows (Section 4.2.1, Page 39):
     ```Initially, companies shall calculate and report, as part of PCF data exchange, on at least one of the following metrics: [...]```  
 
 

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1,9 +1,9 @@
 <pre class='metadata'>
-Title: Technical Specifications for PCF Data Exchange (Version 2.0.1-20230720)
+Title: Technical Specifications for PCF Data Exchange (Version 2.0.1-20230925)
 Shortname: data-exchange-protocol
 Level: 1
 Status: LD
-ED: https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230720/
+ED: https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230925/
 TR: https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/
 Mailing List: public-dev@pathfinder.sine.dev
 Editor: Martin Pompéry (SINE Foundation), https://sine.foundation, martin@sine.foundation
@@ -209,7 +209,7 @@ A ProductFootprint has the following properties:
         <td>String
         <td>M
         <td>
-            The version of the ProductFootprint data specification with value `2.0.1-20230720`.
+            The version of the ProductFootprint data specification with value `2.0.1-20230925`.
 
             Advisement: Subsequent revisions will update this value according to [Semantic Versioning 2.0.0](https://semver.org/lang/en/).
       <tr>
@@ -621,21 +621,23 @@ Advisement:
       <tr>
         <td><dfn>primaryDataShare</dfn> : [=Percent=]
         <td>Number
-        <td>O*
+        <td>O
         <td>
-          The share of primary data in percent. See the [=Pathfinder Framework=] Section 4.2.2.
+          The share of primary data in percent. See the [=Pathfinder Framework=] Sections 4.2.1 and 4.2.2, Appendix B.
 
-          For reporting periods ending before 2025 and if this property is present, the property <{CarbonFootprint/dqi}> MUST NOT be defined.
+          For reporting periods ending before the beginning of year 2025, at least property <{CarbonFootprint/primaryDataShare}> or propery <{CarbonFootprint/dqi}> MUST be defined.
 
-          For reporting periods including the beginning of year 2025 or after, this property MUST be defined.					
+          For reporting periods including the beginning of year 2025 or after, this property MUST be defined.	
       <tr>
         <td><dfn>dqi</dfn> : <{DataQualityIndicators}>
         <td>Object
-        <td>O*
+        <td>O
         <td>
-          If present, the Data Quality Indicators (dqi) in accordance with the [=Pathfinder Framework=].
+          If present, the Data Quality Indicators (dqi) in accordance with the [=Pathfinder Framework=] Sections 4.2.1 and 4.2.3, Appendix B.
 
-          See <{CarbonFootprint/primaryDataShare}> for further details.					
+          For reporting periods ending before the beginning of year 2025, at least property <{CarbonFootprint/primaryDataShare}> or propery <{CarbonFootprint/dqi}> MUST be defined.
+
+          For reporting periods including the beginning of year 2025 or after, this property MUST be defined.					
       <tr>
         <td><dfn>assurance</dfn> : <{Assurance}>
         <td>Object
@@ -2222,6 +2224,16 @@ path: LICENSE.md
 
 
 # Appendix B: Changelog # {#changelog}
+
+
+## Version 2.0.1-20230925 (Sep 25, 2023) ## {#changelog-2.0.1-20230925}
+
+Summary of changes:
+
+1. a definition fix on the definedness for properties <{CarbonFootprint/primaryDataShare}> and <{CarbonFootprint/dqi}>: 
+    previously, they were defined in a mutual-exclusive fashion (either one must be defined but *NOT* both) while the Pathfinder Framework Version 2.0 defines them as follows (Section 4.2.1, Page 39):
+    ```Initially, companies shall calculate and report, as part of PCF data exchange, on at least one of the following metrics: [...]```  
+
 
 
 ## Version 2.0.1-20230720 (Jul 20, 2023) ## {#changelog-2.0.1-20230720}

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1,9 +1,9 @@
 <pre class='metadata'>
-Title: Technical Specifications for PCF Data Exchange (Version 2.0.1-20230925)
+Title: Technical Specifications for PCF Data Exchange (Version 2.0.1-20230926)
 Shortname: data-exchange-protocol
 Level: 1
 Status: LD
-ED: https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230925/
+ED: https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230926/
 TR: https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/
 Mailing List: public-dev@pathfinder.sine.dev
 Editor: Martin Pompéry (SINE Foundation), https://sine.foundation, martin@sine.foundation
@@ -209,7 +209,7 @@ A ProductFootprint has the following properties:
         <td>String
         <td>M
         <td>
-            The version of the ProductFootprint data specification with value `2.0.1-20230925`.
+            The version of the ProductFootprint data specification with value `2.0.1-20230926`.
 
             Advisement: Subsequent revisions will update this value according to [Semantic Versioning 2.0.0](https://semver.org/lang/en/).
       <tr>
@@ -2226,7 +2226,7 @@ path: LICENSE.md
 # Appendix B: Changelog # {#changelog}
 
 
-## Version 2.0.1-20230925 (Sep 25, 2023) ## {#changelog-2.0.1-20230925}
+## Version 2.0.1-20230926 (Sep 26, 2023) ## {#changelog-2.0.1-20230926}
 
 Summary of changes:
 

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -621,7 +621,7 @@ Advisement:
       <tr>
         <td><dfn>primaryDataShare</dfn> : [=Percent=]
         <td>Number
-        <td>O
+        <td>O*
         <td>
           The share of primary data in percent. See the [=Pathfinder Framework=] Sections 4.2.1 and 4.2.2, Appendix B.
 
@@ -631,7 +631,7 @@ Advisement:
       <tr>
         <td><dfn>dqi</dfn> : <{DataQualityIndicators}>
         <td>Object
-        <td>O
+        <td>O*
         <td>
           If present, the Data Quality Indicators (dqi) in accordance with the [=Pathfinder Framework=] Sections 4.2.1 and 4.2.3, Appendix B.
 


### PR DESCRIPTION
The previous version was not in sync with the Pathfinder Framework which states **at least 1** (rather than **exactly 1**) of the above properties MUST be defined.