### PR TITLE
chore: bump version number

### DIFF
--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Title: Technical Specifications for PCF Data Exchange
-Text Macro: VERSION 2.1.0
+Text Macro: VERSION 2.1.1-wip
 Shortname: data-exchange-protocol
 Level: 1
 Status: LD


### PR DESCRIPTION
Bumps version number to `2.1.1-wip` after the `2.1.0` release