### PR TITLE
ADR0028: deprecation of property `characterizationFactors` ; addition of new property `characterizationFactorsSources`

### DIFF
--- a/decisions/log/0027-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0027-provide-clarity-on-characterization-factors.md
@@ -1,0 +1,60 @@
+# 27. Provide Clarity on Characterization Factors (AR5 and AR6)
+
+Date: [YYYY-MM-DD]
+
+## Status
+
+Proposed
+
+## Context
+
+`characterizationFactors` is a mandatory property of the `CarbonFootprint` data type.
+It's data type is `String` and the value MUST be one of the following (see [4.2.2 Properties #characterizationFactors](https://wbcsd.github.io/tr/data-exchange-protocol/#element-attrdef-carbonfootprint-characterizationfactors)):
+- AR6
+  - for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
+- AR5
+  - for the Fifth Assessment Report of the IPCC
+
+However, some PCFs might be calculated with inputs that use both AR5 and AR6 as these can come from
+different sources (i.e., different actors in the supply chain). Since the IPCC will keep publishing
+reports, this problem tends to get worse in the future.
+
+In the context of the Methodology Working Group, PACT members have expressed a very strong
+preference for having the possibility of including more than one characterization factor per PCF.
+
+## Decision
+
+1. Change the definition of the `characterizationFactors` from (roughly):
+    > The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=]   Section 3.2.2). The value MUST be one of the following: [...]
+
+    to:
+    > **Deprecated**
+    >
+    > The IPCC version of the GWP characterization factors used **for the largest relative share of the PCF** in **ist** calculation (see [=Pathfinder Framework=]   Section 3.2.2). The value MUST be one of the following: [...]
+    >
+    > [...]
+    >
+    > **Note: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property `characterizationFactorsList`.**
+
+    (Please refer to the proposed changes to the technical specification for a more detailed and complete diff.)
+
+2. Add the new mandatory property `characterizationFactorsList` with the new data type `CharacterizationFactorsSet`, defined as a non-empty `Object`, such that:
+   1. it has two **Optional** properties `ar5` and `ar6`, both of which have `Percent` values;
+   2. the sum total of the values cannot exceed 100.
+   3. the key of the highest value must match the value of the `characterizationFactors` property (where `ar5` corresponds to `"AR5"` and `ar6` to `"AR6"`). If both values are equal, any of them can be used as the value of `characterizationFactors`.
+
+
+### Rationale
+
+This proposal aims at providing a forward-looking change that improves clarity on characterization factors while preserving backwards-compatibility.
+
+Backwards-compatibility is preserved by keeping the `characterizationFactors` property (despite its becoming deprecated).
+
+Clarity on characterization factors is improved as the PCF now states clearly whether one or more characterization factors were used, with the possibility of specifying the extend to which each was used. In case the Host System cannot achieve such fine-grained information, they can either provide an approximation or set both to `50`.
+
+It is forward-looking as it preserves the possibility of adding further properties to the `CharacterizationFactorsSet` data type, such as further characterization factors, or more utility driven properties like `uknown`.
+
+## Consequences
+
+1. This ADR introduces a minor change: since the `characterizationFactors` property is maintained, it is backwards compatible.
+2. Accordingly, the Technical Specifications version number must be updated from 2.1.x to 2.2.0.

--- a/decisions/log/0027-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0027-provide-clarity-on-characterization-factors.md
@@ -24,35 +24,29 @@ preference for having the possibility of including more than one characterizatio
 
 ## Decision
 
-1. Change the definition of the `characterizationFactors` from (roughly):
+1. Change the definition of the `characterizationFactors` from:
     > The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=]   Section 3.2.2). The value MUST be one of the following: [...]
 
-    to:
+    to (roughly):
     > **Deprecated**
     >
     > The IPCC version of the GWP characterization factors used **in the calculation of the largest relative share of the PCF** (see [=Pathfinder Framework=]   Section 3.2.2). The value MUST be one of the following: [...]
     >
     > [...]
     >
-    > **Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property `characterizationFactorsList`.**
+    > **Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property `characterizationFactorsSources`.**
 
     (Please refer to the proposed changes to the technical specification for a more detailed and complete diff.)
 
-2. Add the new mandatory property `characterizationFactorsList` with the new data type `CharacterizationFactorsList`, defined as a non-empty `Object`, such that:
-   1. it has two **Optional** properties `ar5` and `ar6`, both of which have `Percent` values;
-   2. the sum total of the values cannot exceed 100.
-   3. the key of the highest value must match the value of the `characterizationFactors` property (where `ar5` corresponds to `"AR5"` and `ar6` to `"AR6"`). If both values are equal, any of them can be used as the value of `characterizationFactors`.
-
+2. Add the new mandatory property `characterizationFactorsSources` with the new data type `CharacterizationFactorsSources`, defined as a non-empty `Array` of `CharacterizationFactorsSource`. The new data type `CharacterizationFactorsSource` is defined as an `Object` with the mandatory fields `"name"` and `"version"`, both of which are non-empty `Strings`. The value of the `"name"` field SHOULD be `"IPCC Assessment Report"` and the version SHOULD be either `"5"` or `"6"`.
 
 ### Rationale
 
-This proposal aims at providing a forward-looking change that improves clarity on characterization factors while preserving backwards-compatibility.
+This proposal aims at providing a forward-looking change on characterization factors while preserving backwards-compatibility.
 
 Backwards-compatibility is preserved by keeping the `characterizationFactors` property (despite its becoming deprecated).
 
-Clarity on characterization factors is improved as the PCF now states clearly whether one or more characterization factors were used, with the possibility of specifying the extend to which each was used. In case the Host System cannot achieve such fine-grained information, they can either provide an approximation or set both to `50`.
-
-It is forward-looking as it preserves the possibility of adding further properties to the `CharacterizationFactorsSet` data type, such as further characterization factors, or more utility driven properties like `uknown`.
+It is forward-looking as future adaptations will hardly break backwards-compatibility. If a more fine-grained account of characterization factors use is ever desired, it can be included through optional properties of `CharacterizationFactorsSource`. If ever other sources become relevant (e.g., for specific industries) this too can be acommodated without the need for a breaking change.
 
 ## Consequences
 

--- a/decisions/log/0027-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0027-provide-clarity-on-characterization-factors.md
@@ -30,15 +30,15 @@ preference for having the possibility of including more than one characterizatio
     to:
     > **Deprecated**
     >
-    > The IPCC version of the GWP characterization factors used **for the largest relative share of the PCF** in **ist** calculation (see [=Pathfinder Framework=]   Section 3.2.2). The value MUST be one of the following: [...]
+    > The IPCC version of the GWP characterization factors used **in the calculation of the largest relative share of the PCF** (see [=Pathfinder Framework=]   Section 3.2.2). The value MUST be one of the following: [...]
     >
     > [...]
     >
-    > **Note: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property `characterizationFactorsList`.**
+    > **Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property `characterizationFactorsList`.**
 
     (Please refer to the proposed changes to the technical specification for a more detailed and complete diff.)
 
-2. Add the new mandatory property `characterizationFactorsList` with the new data type `CharacterizationFactorsSet`, defined as a non-empty `Object`, such that:
+2. Add the new mandatory property `characterizationFactorsList` with the new data type `CharacterizationFactorsList`, defined as a non-empty `Object`, such that:
    1. it has two **Optional** properties `ar5` and `ar6`, both of which have `Percent` values;
    2. the sum total of the values cannot exceed 100.
    3. the key of the highest value must match the value of the `characterizationFactors` property (where `ar5` corresponds to `"AR5"` and `ar6` to `"AR6"`). If both values are equal, any of them can be used as the value of `characterizationFactors`.

--- a/decisions/log/0028-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0028-provide-clarity-on-characterization-factors.md
@@ -4,7 +4,7 @@ Date: 2024-01-16
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/decisions/log/0028-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0028-provide-clarity-on-characterization-factors.md
@@ -1,4 +1,4 @@
-# 27. Provide Clarity on Characterization Factors (AR5 and AR6)
+# 28. Provide Clarity on Characterization Factors (AR5 and AR6)
 
 Date: [YYYY-MM-DD]
 

--- a/decisions/log/0028-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0028-provide-clarity-on-characterization-factors.md
@@ -16,8 +16,7 @@ It's data type is `String` and the value MUST be one of the following (see [4.2.
   - for the Fifth Assessment Report of the IPCC
 
 However, some PCFs might be calculated with inputs that use both AR5 and AR6 as these can come from
-different sources (i.e., different actors in the supply chain). Since the IPCC will keep publishing
-reports, this problem tends to get worse in the future.
+different sources (i.e., different actors in the supply chain). Since the IPCC will keep publishing reports (at an expected cadence of at least 5 years between reports), this problem tends to get worse in the future.
 
 In the context of the Methodology Working Group, PACT members have expressed a very strong
 preference for having the possibility of including more than one characterization factor per PCF.
@@ -46,7 +45,7 @@ This proposal aims at providing a forward-looking change on characterization fac
 
 Backwards-compatibility is preserved by keeping the `characterizationFactors` property (despite its becoming deprecated).
 
-It is forward-looking as future adaptations will hardly break backwards-compatibility. If a more fine-grained account of characterization factors use is ever desired, it can be included through optional properties of `CharacterizationFactorsSource`. If ever other sources become relevant (e.g., for specific industries) this too can be acommodated without the need for a breaking change.
+It is forward-looking because future adaptations are unlikely to break backwards-compatibility. If a more fine-grained account of characterization factors use is ever desired, it can be included through optional properties of `CharacterizationFactorsSource`. If ever other sources become relevant (e.g., for specific industries) this too can be acommodated without the need for a breaking change.
 
 ## Consequences
 

--- a/decisions/log/0028-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0028-provide-clarity-on-characterization-factors.md
@@ -1,6 +1,6 @@
 # 28. Provide Clarity on Characterization Factors (AR5 and AR6)
 
-Date: [YYYY-MM-DD]
+Date: 2024-01-16
 
 ## Status
 
@@ -52,3 +52,4 @@ It is forward-looking as future adaptations will hardly break backwards-compatib
 
 1. This ADR introduces a minor change: since the `characterizationFactors` property is maintained, it is backwards compatible.
 2. Accordingly, the Technical Specifications version number must be updated from 2.1.x to 2.2.0.
+3. Host systems need to validate the new property `characterizationFactorsSources` depending on the value of ProductFootprint's property `specsVersion`

--- a/decisions/log/0028-provide-clarity-on-characterization-factors.md
+++ b/decisions/log/0028-provide-clarity-on-characterization-factors.md
@@ -37,7 +37,7 @@ preference for having the possibility of including more than one characterizatio
 
     (Please refer to the proposed changes to the technical specification for a more detailed and complete diff.)
 
-2. Add the new mandatory property `characterizationFactorsSources` with the new data type `CharacterizationFactorsSources`, defined as a non-empty `Array` of `CharacterizationFactorsSource`. The new data type `CharacterizationFactorsSource` is defined as an `Object` with the mandatory fields `"name"` and `"version"`, both of which are non-empty `Strings`. The value of the `"name"` field SHOULD be `"IPCC Assessment Report"` and the version SHOULD be either `"5"` or `"6"`.
+2. Add the new mandatory property `ipccCharacterizationFactorsSources` defined as a non-empty `Array` of `Strings` with the format `AR$VERSION$`, where `$VERSION$` stands for the IPCC report version number and MUST be an integer.
 
 ### Rationale
 
@@ -51,4 +51,4 @@ It is forward-looking because future adaptations are unlikely to break backwards
 
 1. This ADR introduces a minor change: since the `characterizationFactors` property is maintained, it is backwards compatible.
 2. Accordingly, the Technical Specifications version number must be updated from 2.1.x to 2.2.0.
-3. Host systems need to validate the new property `characterizationFactorsSources` depending on the value of ProductFootprint's property `specsVersion`
+3. Host systems need to validate the new property `ipccCharacterizationFactorsSources` depending on the value of ProductFootprint's property `specsVersion`

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -507,7 +507,7 @@ Advisement:
         <td><dfn>characterizationFactorsSources</dfn>  : [=CharacterizationFactorsSourcesSet=]
         <td>Array
         <td>M
-        <td>The set of characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a [=CharacterizationFactorsSourcesSet=].
+        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a [=CharacterizationFactorsSourcesSet=].
       <tr>
         <td><dfn>crossSectoralStandardsUsed</dfn> : [=CrossSectoralStandardSet=]
         <td>Array

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1404,13 +1404,14 @@ A `CharacterizationFactorsSource` references a source of the characterization fa
 ### Properties ### {#dt-characterizationfactorssource-properties}
 
 <dl dfn-type="element-attr" dfn-for="CharacterizationFactorsSource">
+: <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=]) :: The non-empty name of the
+characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`,
+referring to the characterization factors (100-year GWP, including carbon feedbacks) derived from
+the IPCC Assessment Report publication.
 
-: <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=])
-:: The non-empty name of the characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`.
-
-: <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=])
-:: The non-empty version of the characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"` (referring to AR5 and AR6, respectively).
-
+: <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=]) :: The non-empty version of the
+characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"`, referring to
+the 5th (AR5) and 6th (AR6) IPCC Assessment Reports, respectively.
 </dl>
 
 <div class=example>

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -502,12 +502,12 @@ Advisement:
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
 
-          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed on version 3 of these Technical Specifications. It does not replace the (also mandatory) property [=characterizationFactorsSources=].
+          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed on version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/characterizationFactorsSources}>.
       <tr>
-        <td><dfn>characterizationFactorsSources</dfn>  : <{CharacterizationFactorsSourcesSet}>
+        <td><dfn>characterizationFactorsSources</dfn>  : [=CharacterizationFactorsSourcesSet=]
         <td>Array
         <td>M
-        <td>The non-empty set of [=CharacterizationFactorsSource=] used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2).
+        <td>The set of characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a [=CharacterizationFactorsSourcesSet=].
       <tr>
         <td><dfn>crossSectoralStandardsUsed</dfn> : [=CrossSectoralStandardSet=]
         <td>Array
@@ -1389,9 +1389,9 @@ Example JSON string value:
 ```
 </div>
 
-## Data Type: <df element>CharacterizationFactorsSourcesSet</dfn> ## {#dt-characterizationfactorssourcesset}
+## Data Type: <dfn>CharacterizationFactorsSourcesSet</dfn> ## {#dt-characterizationfactorssourcesset}
 
-A set of <{CharacterizationFactorsSource|Characterization Factors Sources}> of size 1 or larger.
+A set of 1 or more <{CharacterizationFactorsSource|Characterization Factors Sources}>.
 
 ### JSON Representation ### {#dt-characterizationfactorssourcesset-json}
 
@@ -1414,7 +1414,7 @@ A `CharacterizationFactorsSource` references a source of the characterization fa
 </dl>
 
 <div class=example>
-Example encoding of a <{EmissionFactorDS}> in JSON:
+Example encoding of a <{CharacterizationFactorsSource}> in JSON:
 
 ```json
 {
@@ -1425,7 +1425,7 @@ Example encoding of a <{EmissionFactorDS}> in JSON:
 </div>
 
 
-### JSON Representation ### {#dt-emissionfactords-json}
+### JSON Representation ### {#dt-characterizationfactorssource-json}
 
 Each <{CharacterizationFactorsSource}> MUST be encoded as a JSON object.
 

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -503,10 +503,10 @@ Advisement:
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
       <tr>
-        <td><dfn>characterizationFactorsSources</dfn>  : [=CharacterizationFactorsSources=]
+        <td><dfn>characterizationFactorsSources</dfn>  : <{CharacterizationFactorsSource}>[]
         <td>Array
         <td>M
-        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a non-empty set of [=CharacterizationFactorsSources=].
+        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a non-empty set of <{CharacterizationFactorsSource}>.
 
           Advisement: Per the Framework, the latest available characterization factor version shall be used. In the event this is not possible, include the set of all characterization factors used.
       <tr>
@@ -1397,12 +1397,14 @@ A `CharacterizationFactorsSource` references a source of the characterization fa
 ### Properties ### {#dt-characterizationfactorssource-properties}
 
 <dl dfn-type="element-attr" dfn-for="CharacterizationFactorsSource">
-: <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=]) :: The non-empty name of the
+: <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=])
+:: The non-empty name of the
     characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`,
     referring to the characterization factors (100-year GWP, including carbon feedbacks) derived from
     the IPCC Assessment Report publication.
 
-: <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=]) :: The non-empty version of the
+: <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=])
+:: The non-empty version of the
     characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"`, referring to
     the 5th (AR5) and 6th (AR6) IPCC Assessment Reports, respectively.
     </dl>

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -505,7 +505,7 @@ Advisement:
           Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed on version 3 of these Technical Specifications. It does not replace the (also mandatory) property [=characterizationFactorsSources=].
       <tr>
         <td><dfn>characterizationFactorsSources</dfn>  : <{CharacterizationFactorsSourcesSet}>
-        <td>Object
+        <td>Array
         <td>M
         <td>The non-empty set of [=CharacterizationFactorsSource=] used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2).
       <tr>

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -502,7 +502,7 @@ Advisement:
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
 
-          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property [=cjaracterizationFactorsList=].
+          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed on version 3 of these Technical Specifications. It does not replace the (also mandatory) property [=characterizationFactorsSources=].
       <tr>
         <td><dfn>characterizationFactorsSources</dfn>  : <{CharacterizationFactorsSourcesSet}>
         <td>Object

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Title: Technical Specifications for PCF Data Exchange
-Text Macro: VERSION 2.1.1-wip
+Text Macro: VERSION 2.2.0-20240312
 Shortname: data-exchange-protocol
 Level: 1
 Status: LD
@@ -494,7 +494,7 @@ Advisement:
         <td>M
         <td>
 
-          Advisement: This property is DEPRECATED and only kept to ensure backwards-compatibility. It will be removed in version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/characterizationFactorsSources}>.
+          Advisement: This property is DEPRECATED and only kept to ensure backwards-compatibility. It will be removed in version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/ipccCharacterizationFactorsSources}>.
 
           The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). In case several characterization factors are used, indicate the earliest version used in your calculations, disregarding supplier provided PCFs. The value MUST be one of the following:
 
@@ -2302,6 +2302,13 @@ path: LICENSE.md
 
 
 # Appendix B: Changelog # {#changelog}
+
+## Version 2.2.0-20240312 (Mar 12, 2024) ## {#changelog-2.2.0-20240312}
+
+Summary of changes:
+
+1. deprecation of the <{CarbonFootprint/characterizationFactors}> property
+2. addition of a new <{CarbonFootprint/ipccCharacterizationFactorsSources}> property
 
 ## Version 2.1.0 (Dec 07, 2023) ## {#changelog-2.1.0}
 

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -502,13 +502,19 @@ Advisement:
           :: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
-      <tr>
-        <td><dfn>characterizationFactorsSources</dfn>  : <{CharacterizationFactorsSource}>[]
-        <td>Array
+     <tr>
+        <td><dfn>ipccCharacterizationFactorsSources</dfn>
+        <td>Array of Strings
         <td>M
-        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a non-empty set of <{CharacterizationFactorsSource}>.
+        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2).
+              It MUST be a non-empty set of strings with the format `AR$VERSION$`, where `$VERSION$` stands for the
+              IPCC report version number and MUST be an integer.
 
-          Advisement: Per the Framework, the latest available characterization factor version shall be used. In the event this is not possible, include the set of all characterization factors used.
+          Example values:
+          <div class=example>["AR6"]</div>
+          <div class=example>["AR5", "AR6"]</div>
+
+          Advisement: Per the Framework, the latest available characterization factor version shall be used, i.e., `["AR6"]`. In the event this is not possible, include the set of all characterization factors used.
       <tr>
         <td><dfn>crossSectoralStandardsUsed</dfn> : [=CrossSectoralStandardSet=]
         <td>Array
@@ -1389,41 +1395,6 @@ Example JSON string value:
 "f4b1225a-bd44-4c8e-861d-079e4e1dfd69"
 ```
 </div>
-
-## Data Type: <dfn element>CharacterizationFactorsSource</dfn> ## {#dt-characterizationfactorssource}
-
-A `CharacterizationFactorsSource` references a source of the characterization factors used in the calculation of the <{CarbonFootprint}> (see [=Pathfinder Framework=] Section 3.2.2).
-
-### Properties ### {#dt-characterizationfactorssource-properties}
-
-<dl dfn-type="element-attr" dfn-for="CharacterizationFactorsSource">
-: <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=])
-:: The non-empty name of the
-    characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`,
-    referring to the characterization factors (100-year GWP, including carbon feedbacks) derived from
-    the IPCC Assessment Report publication.
-
-: <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=])
-:: The non-empty version of the
-    characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"`, referring to
-    the 5th (AR5) and 6th (AR6) IPCC Assessment Reports, respectively.
-    </dl>
-
-<div class=example>
-Example encoding of a <{CharacterizationFactorsSource}> in JSON:
-
-```json
-{
-  "name": "IPCC Assessment Report",
-  "version": "6"
-}
-```
-</div>
-
-
-### JSON Representation ### {#dt-characterizationfactorssource-json}
-
-Each <{CharacterizationFactorsSource}> MUST be encoded as a JSON object.
 
 # Product Footprint Lifecycle # {#lifecycle}
 

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -493,9 +493,9 @@ Advisement:
         <td>String
         <td>M
         <td>
-            **Deprecated**
+          **Deprecated**
 
-            The IPCC version of the GWP characterization factors used in the calculation of the largest relative share of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be one of the following:
+          The IPCC version of the GWP characterization factors used in the calculation of the largest relative share of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be one of the following:
 
           : `AR6`
           :: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
@@ -504,12 +504,10 @@ Advisement:
 
           Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property [=cjaracterizationFactorsList=].
       <tr>
-        <td><dfn>characterizationFactorsList</dfn>  : <{CharacterizationFactorsList}>
+        <td><dfn>characterizationFactorsSources</dfn>  : <{CharacterizationFactorsSourcesSet}>
         <td>Object
         <td>M
-        <td>The non-empty list of characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2) including the percentages of the PCF that correspond to each characterization factor. See <{CharacterizationFactorsList}> for details.
-
-        Advisement: The set of characterization factor identifiers will likely change in future revisions. It is recommended to account for this when implementing the validation of this property.
+        <td>The non-empty set of [=CharacterizationFactorsSource=] used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2).
       <tr>
         <td><dfn>crossSectoralStandardsUsed</dfn> : [=CrossSectoralStandardSet=]
         <td>Array
@@ -1391,30 +1389,45 @@ Example JSON string value:
 ```
 </div>
 
-## Data Type: <dfn>CharacterizationFactors</dfn> ## {#dt-characterizationfactors}
+## Data Type: <df element>CharacterizationFactorsSourcesSet</dfn> ## {#dt-characterizationfactorssourcesset}
 
-The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2).
+A set of <{CharacterizationFactorsSource|Characterization Factors Sources}> of size 1 or larger.
 
-Valid values are:
-: `ar6`
-:: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
-: `ar6`
-:: for the Fifth Assessment Report of the IPCC.
+### JSON Representation ### {#dt-characterizationfactorssourcesset-json}
 
-### JSON Representation ### {#dt-characterizationfactors-json}
+As an array of objects, with each object conforming to the JSON representation of <{CharacterizationFactorsSource}>.
 
-Each CharacterizationFactors MUST be encoded as a JSON string.
+## Data Type: <dfn element>CharacterizationFactorsSource</dfn> ## {#dt-characterizationfactorssource}
 
-## Data Type: CharacterizationFactorsList ## {#dt-characterizationfactorslist}
+A `CharacterizationFactorsSource` references a source of the characterization factors used in the calculation of the <{CarbonFootprint}> (see [=Pathfinder Framework=] Section 3.2.2).
 
-A CharacterizationFactorsList represents the weighted list of [=CharacterizationFactors=] used for the calculation of the PCF. A CharacterizationFactorsList MUST contain at least one entry. A CharacterizationFactorsList has CharacterizationFactors as keys and percentages as values. The sum total of the values of a CharacterizationFactorsList MUST NOT exceed 100.
+### Properties ### {#dt-characterizationfactorssource-properties}
 
-### Properties
+<dl dfn-type="element-attr" dfn-for="CharacterizationFactorsSource">
 
-: ar5 (optional, data type: [=Percent=])
-:: The percentage of the [=CharacterizationFactors=] of the Fifth Assessment Report of the IPCC used for the calculation of the PCF.
-: ar6 (optional, data type: [=Percent=])
-:: The percentage of the [=CharacterizationFactors=] of the Sixth Assessment Report of the IPCC used for the calculation of the PCF.
+: <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=])
+:: The non-empty name of the characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`.
+
+: <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=])
+:: The non-empty version of the characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"` (referring to AR5 and AR6, respectively).
+
+</dl>
+
+<div class=example>
+Example encoding of a <{EmissionFactorDS}> in JSON:
+
+```json
+{
+  "name": "IPCC Assessment Report",
+  "version": "6"
+}
+```
+</div>
+
+
+### JSON Representation ### {#dt-emissionfactords-json}
+
+Each <{CharacterizationFactorsSource}> MUST be encoded as a JSON object.
 
 # Product Footprint Lifecycle # {#lifecycle}
 
@@ -2273,7 +2286,7 @@ date: Mon, 23 May 2022 19:33:16 GMT
 content-type: application/json
 content-length: 1831
 server: Pathfinder
-link: &lt;https://api.pathfinder.sine.dev/2/footprints?limit=10&amp;offset=10&gt;; rel="next"
+link: &lt;https://api.pathfinder.sine.dev/2/footprints?limit=10&offset=10&gt;; rel="next"
 </pre>
 
 Example response body:

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -495,7 +495,7 @@ Advisement:
         <td>
           **Deprecated**
 
-          The IPCC version of the GWP characterization factors used in the calculation of the largest relative share of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be one of the following:
+          The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). In case several characterization factors are used, indicate the earliest version used in your calculations, disregarding supplier provided PCFs. The value MUST be one of the following:
 
           : `AR6`
           :: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -493,7 +493,8 @@ Advisement:
         <td>String
         <td>M
         <td>
-          **Deprecated**
+
+          Advisement: This property is DEPRECATED and only kept to ensure backwards-compatibility. It will be removed in version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/characterizationFactorsSources}>.
 
           The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). In case several characterization factors are used, indicate the earliest version used in your calculations, disregarding supplier provided PCFs. The value MUST be one of the following:
 
@@ -501,13 +502,11 @@ Advisement:
           :: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
-
-          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed in version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/characterizationFactorsSources}>.
       <tr>
-        <td><dfn>characterizationFactorsSources</dfn>  : [=CharacterizationFactorsSourcesSet=]
+        <td><dfn>characterizationFactorsSources</dfn>  : [=CharacterizationFactorsSources=]
         <td>Array
         <td>M
-        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a [=CharacterizationFactorsSourcesSet=].
+        <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a non-empty set of [=CharacterizationFactorsSources=].
 
           Advisement: Per the Framework, the latest available characterization factor version shall be used. In the event this is not possible, include the set of all characterization factors used.
       <tr>
@@ -1390,14 +1389,6 @@ Example JSON string value:
 "f4b1225a-bd44-4c8e-861d-079e4e1dfd69"
 ```
 </div>
-
-## Data Type: <dfn>CharacterizationFactorsSourcesSet</dfn> ## {#dt-characterizationfactorssourcesset}
-
-A set of 1 or more <{CharacterizationFactorsSource|Characterization Factors Sources}>.
-
-### JSON Representation ### {#dt-characterizationfactorssourcesset-json}
-
-As an array of objects, with each object conforming to the JSON representation of <{CharacterizationFactorsSource}>.
 
 ## Data Type: <dfn element>CharacterizationFactorsSource</dfn> ## {#dt-characterizationfactorssource}
 

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -502,12 +502,14 @@ Advisement:
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
 
-          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed on version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/characterizationFactorsSources}>.
+          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It will be removed in version 3 of these Technical Specifications. It does not replace the (also mandatory) property <{CarbonFootprint/characterizationFactorsSources}>.
       <tr>
         <td><dfn>characterizationFactorsSources</dfn>  : [=CharacterizationFactorsSourcesSet=]
         <td>Array
         <td>M
         <td>The characterization factors from one or more IPCC Assessment Reports used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be a [=CharacterizationFactorsSourcesSet=].
+
+          Advisement: Per the Framework, the latest available characterization factor version shall be used. In the event this is not possible, include the set of all characterization factors used.
       <tr>
         <td><dfn>crossSectoralStandardsUsed</dfn> : [=CrossSectoralStandardSet=]
         <td>Array
@@ -1405,14 +1407,14 @@ A `CharacterizationFactorsSource` references a source of the characterization fa
 
 <dl dfn-type="element-attr" dfn-for="CharacterizationFactorsSource">
 : <dfn>name</dfn> (mandatory, data type: [=NonEmptyString=]) :: The non-empty name of the
-characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`,
-referring to the characterization factors (100-year GWP, including carbon feedbacks) derived from
-the IPCC Assessment Report publication.
+    characterization factors source. Presently, the value SHOULD be `"IPCC Assessment Report"`,
+    referring to the characterization factors (100-year GWP, including carbon feedbacks) derived from
+    the IPCC Assessment Report publication.
 
 : <dfn>version</dfn> (mandatory, data type: [=NonEmptyString=]) :: The non-empty version of the
-characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"`, referring to
-the 5th (AR5) and 6th (AR6) IPCC Assessment Reports, respectively.
-</dl>
+    characterization factors source. Presently, the value SHOULD be either `"5"` or `"6"`, referring to
+    the 5th (AR5) and 6th (AR6) IPCC Assessment Reports, respectively.
+    </dl>
 
 <div class=example>
 Example encoding of a <{CharacterizationFactorsSource}> in JSON:
@@ -2287,7 +2289,7 @@ date: Mon, 23 May 2022 19:33:16 GMT
 content-type: application/json
 content-length: 1831
 server: Pathfinder
-link: &lt;https://api.pathfinder.sine.dev/2/footprints?limit=10&offset=10&gt;; rel="next"
+link: &lt;https://api.pathfinder.sine.dev/2/footprints?limit=10&amp;offset=10&gt;; rel="next"
 </pre>
 
 Example response body:

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -493,14 +493,23 @@ Advisement:
         <td>String
         <td>M
         <td>
-            The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be one of the following:
+            **Deprecated**
+
+            The IPCC version of the GWP characterization factors used in the calculation of the largest relative share of the PCF (see [=Pathfinder Framework=] Section 3.2.2). The value MUST be one of the following:
 
           : `AR6`
           :: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
           : `AR5`
           :: for the Fifth Assessment Report of the IPCC.
 
-          Advisement: The set of characterization factor identifiers will likely change in future revisions. It is recommended to account for this when implementing the validation of this property.
+          Advisement: This property is deprecated and only kept to ensure backwards-compatibility. It does not replace the (also mandatory) property [=cjaracterizationFactorsList=].
+      <tr>
+        <td><dfn>characterizationFactorsList</dfn>  : <{CharacterizationFactorsList}>
+        <td>Object
+        <td>M
+        <td>The non-empty list of characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2) including the percentages of the PCF that correspond to each characterization factor. See <{CharacterizationFactorsList}> for details.
+
+        Advisement: The set of characterization factor identifiers will likely change in future revisions. It is recommended to account for this when implementing the validation of this property.
       <tr>
         <td><dfn>crossSectoralStandardsUsed</dfn> : [=CrossSectoralStandardSet=]
         <td>Array
@@ -1382,6 +1391,30 @@ Example JSON string value:
 ```
 </div>
 
+## Data Type: <dfn>CharacterizationFactors</dfn> ## {#dt-characterizationfactors}
+
+The IPCC version of the GWP characterization factors used in the calculation of the PCF (see [=Pathfinder Framework=] Section 3.2.2).
+
+Valid values are:
+: `ar6`
+:: for the Sixth Assessment Report of the Intergovernmental Panel on Climate Change (IPCC)
+: `ar6`
+:: for the Fifth Assessment Report of the IPCC.
+
+### JSON Representation ### {#dt-characterizationfactors-json}
+
+Each CharacterizationFactors MUST be encoded as a JSON string.
+
+## Data Type: CharacterizationFactorsList ## {#dt-characterizationfactorslist}
+
+A CharacterizationFactorsList represents the weighted list of [=CharacterizationFactors=] used for the calculation of the PCF. A CharacterizationFactorsList MUST contain at least one entry. A CharacterizationFactorsList has CharacterizationFactors as keys and percentages as values. The sum total of the values of a CharacterizationFactorsList MUST NOT exceed 100.
+
+### Properties
+
+: ar5 (optional, data type: [=Percent=])
+:: The percentage of the [=CharacterizationFactors=] of the Fifth Assessment Report of the IPCC used for the calculation of the PCF.
+: ar6 (optional, data type: [=Percent=])
+:: The percentage of the [=CharacterizationFactors=] of the Sixth Assessment Report of the IPCC used for the calculation of the PCF.
 
 # Product Footprint Lifecycle # {#lifecycle}
 


### PR DESCRIPTION
We propose a tech specs changes after consultation with and a decision by the methodology working group. 
A change to the property `characterizationFactors` is necessary to make it possible to express the usage of more than 1 set of characterization factors. 

Summary of this ADR:

1. `characterizationFactors` is deprecated
2. new property `characterizationFactorsSources` is added which has the same "syntax" as CarbonFootprint's property `secondaryEmissionFactorSources` ; i.e. this property is a list (array) of tuples `name` and `version` 

h/t to @raimundo-henriques for authoring this