### PR TITLE
feat: ADR 0030 on `exemptedEmissionsPercent`

### DIFF
--- a/decisions/log/0030-extend-syntactical-allowance-of-exempted-emissions.md
+++ b/decisions/log/0030-extend-syntactical-allowance-of-exempted-emissions.md
@@ -1,0 +1,43 @@
+# 2. Extending the syntactic allowance of exempt emissions
+
+Date: 2024-03-12
+
+## Status
+
+Proposed
+
+## Context
+
+Pathfinder Framework 2.0 limits exempt emissions to 5%.
+
+This is reflected in the Tech Specs accordingly, so the property
+[`exemptedEmissionsPercent`](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/#element-attrdef-carbonfootprint-exemptedemissionspercent) is defined as a percentage between `0` and `5`.
+
+However, feedback has been provided to the Methodology Working Group stating that
+that this limit is too restrictive:
+
+1. PCFs cannot be shared if the exempt emissions exceed 5% - e.g. if they are 5.1% and all other requirements are met.
+2. Companies may be incentivized to report an untrue value in order to meet the synthetic requirements of being 5% or less.
+
+Therefore, the Methodology Working Group proposes the following changes to the tech specs:
+
+1. to remove the upper limit at the **syntactical level**.
+2. while clearly stating that the **methodological** requirement for exempt emissions as is - i.e. at 5% or less.
+
+
+## Decision
+
+The definition of `exemptedEmissionsPercent` is updated from
+
+> The Percentage of emissions excluded from PCF, expressed as a decimal number between `0.0` and `5` including. See [=Pathfinder Framework=].
+
+to
+
+> The percentage of emissions EXCLUDED from the cradle-to-gate PCF in total. The percentage MUST be expressed as a decimal number, and SHOULD comply with the Pathfinder Framework (a maximum of 5% of the cradle to gate PCF emissions may be excluded) as well as any relevant sector-specific guidelines referring to exemption rules/cut-off criteria.
+
+The necessary update to the tech specs will be reflected in the **next major release** (see below).
+
+
+## Consequences
+
+This change breaks backwards compatibility.

--- a/decisions/log/0030-extend-syntactical-allowance-of-exempted-emissions.md
+++ b/decisions/log/0030-extend-syntactical-allowance-of-exempted-emissions.md
@@ -33,7 +33,7 @@ The definition of `exemptedEmissionsPercent` is updated from
 
 to
 
-> The percentage of emissions EXCLUDED from the cradle-to-gate PCF in total. The percentage MUST be expressed as a decimal number, and SHOULD comply with the Pathfinder Framework (a maximum of 5% of the cradle to gate PCF emissions may be excluded) as well as any relevant sector-specific guidelines referring to exemption rules/cut-off criteria.
+> Percentage of emissions EXCLUDED from the cradle to gate PCF in total. The percentage MUST be expressed as a decimal number, and SHOULD comply with the Pathfinder Framework (a maximum of 5% of the cradle-to-gate PCF emissions may be excluded) as well as any relevant sector specific guidelines referring to exemption rules/cut-off criteria.
 
 The necessary update to the tech specs will be reflected in the **next major release** (see below).
 

--- a/decisions/log/0030-extend-syntactical-allowance-of-exempted-emissions.md
+++ b/decisions/log/0030-extend-syntactical-allowance-of-exempted-emissions.md
@@ -1,4 +1,4 @@
-# 2. Extending the syntactic allowance of exempt emissions
+# 30. Extending the syntactic allowance of exempt emissions
 
 Date: 2024-03-12
 
@@ -8,13 +8,13 @@ Proposed
 
 ## Context
 
-Pathfinder Framework 2.0 limits exempt emissions to 5%.
+Pathfinder Framework 2.0 limits exempted emissions to 5%.
 
 This is reflected in the Tech Specs accordingly, so the property
 [`exemptedEmissionsPercent`](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/#element-attrdef-carbonfootprint-exemptedemissionspercent) is defined as a percentage between `0` and `5`.
 
 However, feedback has been provided to the Methodology Working Group stating that
-that this limit is too restrictive:
+this limit is too restrictive:
 
 1. PCFs cannot be shared if the exempt emissions exceed 5% - e.g. if they are 5.1% and all other requirements are met.
 2. Companies may be incentivized to report an untrue value in order to meet the synthetic requirements of being 5% or less.


### PR DESCRIPTION
ADR 0030 is a follow up on a methodology WG decision related to `exemptedEmissionsPercent` property. 

The consensus is that the current **_syntactical_** limit follows the Pathfinder Framework. 

However, as it disallows any other (i.e. higher) `exemptedEmissionsPercent` value to be exchanged, the **syntax** should be more permissive by dropping this limit altogether. 