### PR TITLE
Add advisements to properties that will become optional in v3

### DIFF
--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -306,7 +306,11 @@ A ProductFootprint has the following properties:
         <td><dfn>productCategoryCpc</dfn> : [=CpcCode=]
         <td>String
         <td>M
-        <td>A UN Product Classification Code (CPC) that the given product belongs to.
+        <td>
+
+        Advisement: This property will become OPTIONAL in version 3 of the Technical Specifications.
+
+        A UN Product Classification Code (CPC) that the given product belongs to.
       <tr>
         <td><dfn>productNameCompany</dfn>
         <td>String
@@ -317,6 +321,9 @@ A ProductFootprint has the following properties:
         <td>String
         <td>M
         <td>
+
+          Advisement: This property will become OPTIONAL in version 3 of the Technical Specifications.
+
           The additional information related to the product footprint.
 
           Whereas the property <{ProductFootprint/productDescription}> contains product-level information, <{ProductFootprint/comment}> SHOULD be used for information and instructions related to the calculation of the footprint, or other information which informs the ability to interpret, to audit or to verify the Product Footprint.
@@ -548,7 +555,11 @@ Advisement:
         <td><dfn>boundaryProcessesDescription</dfn>
         <td>String
         <td>M
-        <td>The processes attributable to each lifecycle stage.
+        <td>
+
+        Advisement: This property will become OPTIONAL in version 3 of the Technical Specifications.
+
+        The processes attributable to each lifecycle stage.
 
         Example text value:
         <div class=example>`Electricity consumption included as an input in the production phase`</div>
@@ -611,7 +622,11 @@ Advisement:
         <td><dfn>exemptedEmissionsDescription</dfn>
         <td>String
         <td>M
-        <td>Rationale behind exclusion of specific PCF emissions, CAN be the empty string if no emissions were excluded.
+        <td>
+
+        Advisement: This property will become OPTIONAL in version 3 of the Technical Specifications.
+
+        Rationale behind exclusion of specific PCF emissions, CAN be the empty string if no emissions were excluded.
       <tr>
         <td><dfn>packagingEmissionsIncluded</dfn>
         <td>Boolean


### PR DESCRIPTION
Adds advisements to properties 

`productCategoryCpc`, `comment`, `boundaryProcessesDescription`, and `exemptedEmissionsDescription`, noting that they will become optional in v3. 

Please find below an example of what the advisements look like when rendered (they are identical for all properties):
<img width="808" alt="Screenshot 2024-03-26 at 12 12 03" src="https://github.com/wbcsd/data-exchange-protocol/assets/100690574/02fd54eb-fe56-43e6-b92a-e77a21271c97">

All feedback is welcome!