### PR TITLE
fix: examples' pCfExcludingBiogenic value

### DIFF
--- a/decisions/log/0026-async-request-by-default.md
+++ b/decisions/log/0026-async-request-by-default.md
@@ -106,7 +106,7 @@ The following changes to the tech spec Bikeshed file[^1] shall be made:
                     "pcf": {
                         "declaredUnit": "liter",
                         "unitaryProductAmount": "12.0",
-                        "pCfExcludingBiogenic": "0.0",
+                        "pCfExcludingBiogenic": "0.123",
                         "fossilGhgEmissions": "0.123",
                         "fossilCarbonContent": "0.0",
                         "biogenicCarbonContent": "0.0",

--- a/spec/v2/examples/invalid-response-all-properties.json
+++ b/spec/v2/examples/invalid-response-all-properties.json
@@ -28,7 +28,7 @@
             "pcf": {
                 "declaredUnit": "liter",
                 "unitaryProductAmount": "12.0",
-                "pCfExcludingBiogenic": "0.0",
+                "pCfExcludingBiogenic": "0.123",
                 "pCfIncludingBiogenic": "0.0",
                 "fossilGhgEmissions": "0.123",
                 "fossilCarbonContent": "1.721",

--- a/spec/v2/examples/list-footprint-response.json
+++ b/spec/v2/examples/list-footprint-response.json
@@ -20,7 +20,7 @@
     "pcf": {
       "declaredUnit": "liter",
       "unitaryProductAmount": "12.0",
-      "pCfExcludingBiogenic": "0.0",
+      "pCfExcludingBiogenic": "0.123",
       "fossilGhgEmissions": "0.123",
       "fossilCarbonContent": "0.0",
       "biogenicCarbonContent": "0.0",

--- a/spec/v2/examples/list-footprints-response.json
+++ b/spec/v2/examples/list-footprints-response.json
@@ -21,7 +21,7 @@
       "pcf": {
         "declaredUnit": "liter",
         "unitaryProductAmount": "12.0",
-        "pCfExcludingBiogenic": "0.0",
+        "pCfExcludingBiogenic": "0.123",
         "fossilGhgEmissions": "0.123",
         "fossilCarbonContent": "0.0",
         "biogenicCarbonContent": "0.0",

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -2390,7 +2390,7 @@ Example PF Response Event request body
                 "pcf": {
                     "declaredUnit": "liter",
                     "unitaryProductAmount": "12.0",
-                    "pCfExcludingBiogenic": "0.0",
+                    "pCfExcludingBiogenic": "0.123",
                     "fossilGhgEmissions": "0.123",
                     "fossilCarbonContent": "0.0",
                     "biogenicCarbonContent": "0.0",

--- a/spec/v2/index.bs
+++ b/spec/v2/index.bs
@@ -2567,6 +2567,7 @@ Summary of changes:
 2. clarification of [=PF Request Event=] syntax, including the instruction that the
     [=ProductFootprintFragment=] should refer to one single productm
 3. addition of a recommendation to include [=ProductIds=] in the PF Request Event request body
+4. fixed the incorrect the value of `pCfExcludingBiogenic` in all relevant examples
 
 ## Version 2.2.0-20240320 (Mar 20, 2024) ## {#changelog-2.2.0-20240320}
 


### PR DESCRIPTION
Updates the value of `pCfExcludingBiogenic` in the examples (closes #13).