### PR TITLE
chore: update release plan after tech specs release

### DIFF
--- a/RELEASE-PLAN.md
+++ b/RELEASE-PLAN.md
@@ -34,7 +34,7 @@ In addition, the tables below disclose deprecation of releases and subsequent su
 | [v1.0.0](https://www.carbon-transparency.com/media/1qcdbdyn/pathfinder-network_technical-specifications-for-use-case-001.pdf) | N/A | Jun 16, 2022 | Dec 31, 2023 | Oct 1, 2024 |
 | [v1.0.1](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230201/) | N/A  | Feb 1, 2023 | Dec 31, 2023 | Oct 1, 2024  |
 | [v2.1.0](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/)  | Nov 9, 2023 | Dec 7, 2023 |  | |
-| [v2.2.0](https://wbcsd.github.io/data-exchange-protocol/v2/) | Jan 2024 | April 10, 2024 | |
+| [v2.2.0](https://wbcsd.github.io/tr/2024/data-exchange-protocol-20240410/) | Jan 2024 | April 10, 2024 | |
 | v2.3.0 | Mid Q2 2024 | July 2024 | |
 | v3.0.0 | Q3 2024<br/> | Q4 2024<br/> (released w/ Framework) | |
 


### PR DESCRIPTION
Updates `RELEASE-PLAN.md` to link to the released version.