### PR TITLE
ADR-44 Remove superfluous assurance flag

### DIFF
--- a/decisions/log/0044-remove-assurance-flag.md
+++ b/decisions/log/0044-remove-assurance-flag.md
@@ -50,3 +50,6 @@ As this would break backwards compatibility with version 2.x these changes shoul
 Presented in the Tech Working Group meeting of December 4, 2024. Feedback collected.
 
 Call for consensus Dec 18, 2024.
+Consensus reached.
+
+

--- a/decisions/log/0044-remove-assurance-flag.md
+++ b/decisions/log/0044-remove-assurance-flag.md
@@ -1,4 +1,4 @@
-# 44. Consistent typing of real numbers
+# 44. Remove assurance flag
 
 Date: 2024-12-11
 

--- a/decisions/log/0044-remove-assurance-flag.md
+++ b/decisions/log/0044-remove-assurance-flag.md
@@ -1,0 +1,52 @@
+# 44. Consistent typing of real numbers
+
+Date: 2024-12-11
+
+## Context
+
+In the current Tech Specs (2.x) the Assurance sub-record has a Boolean flag indicating whether or not assurance-related information is given:
+
+```json
+"pcf": {
+	"assurance": {
+		"assurance": true
+		"coverage": "product level"
+		"boundary": "cradle-to-gate"
+		...
+	}
+}
+```
+
+This is superfluous: the presence of the `assurance` subrecord already indicates the inclusion of the assurance-related information, no boolean flag is necessary.
+
+Moreover: setting the assurance attribute to `false` can lead to a confusing situation of setting the other attributes to `null` or empty strings, or omitting them.
+
+## Proposal
+
+Remove the`assurance` attribute and let the presence of an `assurance` sub-record indicate the availability of the information:
+
+```json
+"pcf": {
+	"description": "PCF without assurance"
+}
+```
+
+```json
+"pcf": {
+	"description": "PCF WITH assurance",
+	"assurance": { 
+	  "coverage": "product level"
+		"boundary": "cradle-to-gate"
+	}
+}
+```
+
+## Consequences
+
+As this would break backwards compatibility with version 2.x these changes should - if accepted - be included from version 3 upwards.
+
+## Status
+
+Presented in the Tech Working Group meeting of December 4, 2024. Feedback collected.
+
+Call for consensus Dec 18, 2024.

--- a/spec/v3/index.bs
+++ b/spec/v3/index.bs
@@ -961,6 +961,8 @@ The following properties are defined for data type <{DataQualityIndicators}>:
 
 Data type `Assurance` contains the assurance in conformance with [=PACT Methodology=] chapter 5 and appendix B.
 
+Advisement: the superfluous boolean property `assurance` has been REMOVED in version 3.0. The presence of the <{Assurance}> element indicates whether or not the <{CarbonFootprint}> has been assured in line with [=PACT Methodology=] requirements (section 5). 
+
 The following properties are defined for data type <{Assurance}>:
 
 <figure id="pf-assurance-properties-table" dfn-type="element-attr" dfn-for="Assurance">
@@ -972,13 +974,6 @@ The following properties are defined for data type <{Assurance}>:
         <th>Req
         <th>Specification
     <tbody>
-      <tr>
-        <td><dfn>assurance</dfn>
-        <td>Boolean
-        <td>M
-        <td>
-          A boolean flag indicating whether the <{CarbonFootprint}> has been
-          assured in line with [=PACT Methodology=] requirements (section 5).
       <tr>
         <td><dfn>coverage</dfn>
         <td>String


### PR DESCRIPTION
Boolean property `assurance` on the `assurance` sub-object is not necessary, and can be inconsistent. Proposal to remove it from 3.0