### PR TITLE
Update RELEASE-PLAN in public site.

### DIFF
--- a/RELEASE-PLAN.md
+++ b/RELEASE-PLAN.md
@@ -29,6 +29,7 @@ This release plan indicates timelines of both the PACT Methodology and PACT Tech
 * June 2024: Release pushed from Q4 2024 to Q1 2025 (both methodology and tech specs) given known delay in biogenic chapter and need to use the extra quarter to finalize alignment between Methodology and Technology.
 * December 2024: Deprecation and Sunset dates for V2 need to be determined.
 * February 2025: Removal of Sunset date, going forward we will only set a of Deprecation date to prevent confusion.
+* April 2025: Sunset dates for V2.x set to April 2026.
 
 ## Definitions
 <dl>

--- a/RELEASE-PLAN.md
+++ b/RELEASE-PLAN.md
@@ -8,9 +8,9 @@ This release plan indicates timelines of both the PACT Methodology and PACT Tech
 
 | Version| Draft Release | Published Release | Deprecation |
 | --- | --- | --- | --- |
-| [Version 1](https://wbcsd.github.io/tr/websitedocs/pathfinder_framework_v1.pdf ) | N/A | June 2022 | Oct 1, 2024 |
-| [Version 2](https://wbcsd.github.io/tr/2023/framework-20232601/framework.pdf) | N/A | January 26, 2023 | TBD |
-| Version 3 | January 27, 2025 | April 2025 | TBD |
+| [Version 1](https://wbcsd.github.io/tr/websitedocs/pathfinder_framework_v1.pdf ) | N/A | Jun 2022 | Oct 1, 2024 |
+| [Version 2](https://wbcsd.github.io/tr/2023/framework-20232601/framework.pdf) | N/A | Jan 26, 2023 | TBD |
+| Version 3 | January 27, 2025 | Apr 2025 | TBD |
 
 ## Technical Specifications
 
@@ -18,11 +18,11 @@ This release plan indicates timelines of both the PACT Methodology and PACT Tech
 | --- | --- | --- | --- |
 | [v1.0.0](https://wbcsd.sharepoint.com/:b:/s/ClimateEnergy/ESqCiyrW5jpEmOTfwvLFjTYB9E8pY-vTnBuzIgEI6_K2EQ?e=rUeOBi) | N/A | Jun 16, 2022 | Oct 1, 2024 |
 | [v1.0.1](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230201/) | N/A  | Feb 1, 2023 | Oct 1, 2024  |
-| [v2.0.0](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/)  | Feb 1, 2023 | Feb 21, 2023 |  |
-| [v2.1.0](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/)  | Nov 9, 2023 | Dec 7, 2023 |  |
-| [v2.2.0](https://wbcsd.github.io/tr/2024/data-exchange-protocol-20240410/) | Jan 2024 | Apr 10, 2024 |
-| [v2.3.0](https://wbcsd.github.io/tr/2024/data-exchange-protocol-20241024/) | Oct 2024 | Oct 24, 2024 |
-| [v3.0.0](https://wbcsd.github.io/data-exchange-protocol/v3/) | Feb 2025 | April 2025 |
+| [v2.0.0](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/)  | Feb 1, 2023 | Feb 21, 2023 | Apr 1, 2026 |
+| [v2.1.0](https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/)  | Nov 9, 2023 | Dec 7, 2023 | Apr 1, 2026 |
+| [v2.2.0](https://wbcsd.github.io/tr/2024/data-exchange-protocol-20240410/) | Jan 2024 | Apr 10, 2024 | Apr 1, 2026 |
+| [v2.3.0](https://wbcsd.github.io/tr/2024/data-exchange-protocol-20241024/) | Oct 2024 | Oct 24, 2024 | Apr 1, 2026 |
+| [v3.0.0](https://wbcsd.github.io/data-exchange-protocol/v3/) | Feb 2025 | Apr 2025 | |
 
 ## Notes on Timeline Updates
 * April 2024: Release pushed from Q3 to Q4 2024 (both methodology and tech specs) given learnings in Q1 2024 requiring more time to reach consensus and alignment on all critical topics.

--- a/RELEASE-PLAN.md
+++ b/RELEASE-PLAN.md
@@ -1,8 +1,6 @@
-# Background and Context
+# Release Plan
 
 This release plan indicates timelines of both the PACT Methodology and PACT Technical Specifications.
-
-**As always, the timelines are subject to change.**
 
 ## PACT Methodology
 
@@ -25,11 +23,11 @@ This release plan indicates timelines of both the PACT Methodology and PACT Tech
 | [v3.0.0](https://wbcsd.github.io/data-exchange-protocol/v3/) | Feb 2025 | Apr 2025 | |
 
 ## Notes on Timeline Updates
-* April 2024: Release pushed from Q3 to Q4 2024 (both methodology and tech specs) given learnings in Q1 2024 requiring more time to reach consensus and alignment on all critical topics.
-* June 2024: Release pushed from Q4 2024 to Q1 2025 (both methodology and tech specs) given known delay in biogenic chapter and need to use the extra quarter to finalize alignment between Methodology and Technology.
-* December 2024: Deprecation and Sunset dates for V2 need to be determined.
-* February 2025: Removal of Sunset date, going forward we will only set a of Deprecation date to prevent confusion.
 * April 2025: Sunset dates for V2.x set to April 2026.
+* February 2025: Removal of Sunset date, going forward we will only set a of Deprecation date to prevent confusion.
+* December 2024: Deprecation and Sunset dates for V2 need to be determined.
+* June 2024: Release pushed from Q4 2024 to Q1 2025 (both methodology and tech specs) given known delay in biogenic chapter and need to use the extra quarter to finalize alignment between Methodology and Technology.
+* April 2024: Release pushed from Q3 to Q4 2024 (both methodology and tech specs) given learnings in Q1 2024 requiring more time to reach consensus and alignment on all critical topics.
 
 ## Definitions
 <dl>

--- a/assets/markdown.css
+++ b/assets/markdown.css
@@ -8,6 +8,7 @@
 		--body-color: black;
 		--link-color: #1d5cb5;
 		--logo-url: url(logo.svg);
+		--border-color: #aaa;
 	}
 }
 @media (prefers-color-scheme: dark) {
@@ -15,6 +16,7 @@
 	  --body-bg: black;
 	  --body-color: white;
 	  --link-color: #58a7f9;
+	  --border-color: #eaeaea;
 	  --logo-url: url(logo-dark.svg);
 	}
   }
@@ -107,22 +109,20 @@ ol {
 hr {
 	border: 0;
 	height: 1px;
-	border-bottom: 1px solid;
+	border-bottom: 1px solid var(--border-color);
 }
 
 h1 {
 	font-size: 2em;
 	margin-top: 0;
 	padding-bottom: 0.3em;
-	border-bottom-width: 1px;
-	border-bottom-style: solid;
+	border-bottom: 1px solid var(--border-color);
 }
 
 h2 {
 	font-size: 1.5em;
 	padding-bottom: 0.3em;
-	border-bottom-width: 1px;
-	border-bottom-style: solid;
+	border-bottom: 1px solid var(--border-color);
 }
 
 h3 {
@@ -148,7 +148,7 @@ table {
 
 th {
 	text-align: left;
-	border-bottom: 1px solid;
+	border-bottom: 1px solid var(--border-color);
 }
 
 th,
@@ -157,8 +157,14 @@ td {
 }
 
 table > tbody > tr + tr > td {
-	border-top: 1px solid;
+	border-top: 1px solid var(--border-color);
 }
+
+/*
+tr:nth-child(even) {
+	background-color: var(--vscode-editor-background, #fafafc);
+}
+*/
 
 blockquote {
 	margin: 0;

--- a/index.md
+++ b/index.md
@@ -8,7 +8,9 @@ The PACT Network (previously Pathfinder Network) is an open and global network o
 The PACT Technical Specifications describe the PCF data model and PCF exchange API. For guidance on calculating a PCF, please refer to the latest PACT Methodology on [https://carbon-transparency.org](https://www.carbon-transparency.org/pact-methodology)
 
 All recent versions of the Technical Specifications are published here, including OpenAPI schema and a Simplified Data Model in Excel format.
-For sources and to contribute, please visit the [WBCSD GitHub repository](https://github.com/wbcsd/data-exchange-protocol)
+We welcome contributions, please visit the [WBCSD GitHub repository](https://github.com/wbcsd/data-exchange-protocol)
+
+For timelines, see [RELEASE PLAN](RELEASE-PLAN.html)
 
 ## 3.0.0-pre (living document)
 

--- a/spec/v3/faq.md
+++ b/spec/v3/faq.md
@@ -1,6 +1,4 @@
-<div class="logo"></div>
-
-# FAQ PACT 3.0
+# FAQ
 
 ## Introduction
 
@@ -46,7 +44,7 @@
     
     The release date is planned for late April 2025. 
     
-    [Register for the events here to be part of the launch](https://wbcsd.my.salesforce-sites.com/GuestEventPageV2?aId=a5sVj0000004pFF)! 
+    [Register for the events here to be part of the launch](https://wbcsd.my.salesforce-sites.com/GuestEventPageV2?aId=a5sVj0000004pFF) 
     
 - **Will there be a public review period for V3?**
     
@@ -54,9 +52,9 @@
     
 - **How can the community provide feedback on V3?**
     
-    If you have a GitHub account, please log onto the platform and raise an issue directly on [GitHub](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwbcsd.us7.list-manage.com%2Ftrack%2Fclick%3Fu%3D09b189c2ec748a1656aa81c18%26id%3D612d2488dc%26e%3D42f54b98a7&data=05%7C02%7CChakravarty%40wbcsd.org%7C43e695ccad444b99498c08dd50181300%7C0a4366413742468781073a60c81e1317%7C0%7C0%7C638754786505053669%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=WukabIiOsEBYjfwYLZOwhpTMdYtKrmx1vN5Fj0n6wEc%3D&reserved=0). Alternatively, please share your feedback via email to: [pact@wbcsd.org](mailto:pact@wbcsd.org) and [schuurmans@wbcsd.org](mailto:schuurmans@wbcsd.org).
+    If you have a GitHub account, please log onto the platform and raise an issue directly on [GitHub](https://github.com/wbcsd/data-exchange-protocol/issues). Alternatively, please share your feedback via email to: [pact@wbcsd.org](mailto:pact@wbcsd.org) and [schuurmans@wbcsd.org](mailto:schuurmans@wbcsd.org).
     
-    For in-depth information on rationale behind changes, please visit GitHub the [PACT Backlog](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwbcsd.us7.list-manage.com%2Ftrack%2Fclick%3Fu%3D09b189c2ec748a1656aa81c18%26id%3Db5c21f667a%26e%3D42f54b98a7&data=05%7C02%7CChakravarty%40wbcsd.org%7C43e695ccad444b99498c08dd50181300%7C0a4366413742468781073a60c81e1317%7C0%7C0%7C638754786505068046%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=zLqSB%2FSRoexxWS%2BbSu%2FTVhjyf%2F%2ByHsj7VWz4K6uIxGA%3D&reserved=0) and [PACT on GitHub](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwbcsd.us7.list-manage.com%2Ftrack%2Fclick%3Fu%3D09b189c2ec748a1656aa81c18%26id%3Dd96185f3c0%26e%3D42f54b98a7&data=05%7C02%7CChakravarty%40wbcsd.org%7C43e695ccad444b99498c08dd50181300%7C0a4366413742468781073a60c81e1317%7C0%7C0%7C638754786505081919%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=%2BcKCIvGjNAiAtR2BhGfMssdLyUlXmnzM5xZwC1UNKTE%3D&reserved=0).
+    For in-depth information on rationale behind changes, please visit the [PACT Backlog](https://backlog.carbon-transparency.org) and [PACT on GitHub](https://github.com/wbcsd/data-exchange-protocol).
     
 - **Will there be future releases beyond V3?**
     

--- a/tasks.py
+++ b/tasks.py
@@ -125,6 +125,7 @@ def build(c):
         ])
     build_task([
         Dependency("build/index.html", ["index.md"]), 
+        Dependency("build/release-plan.html", ["RELEASE-PLAN.md"]),
         Dependency("build/v3/faq.html", ["spec/v3/faq.md"])
         ], 
         render_markdown

--- a/tasks.py
+++ b/tasks.py
@@ -47,14 +47,21 @@ def is_repo_pristine(directory = None):
 # Generate html from markdown
 def render_markdown(input, output: str):
     rel_root_path = (output.count('/')-1) * "../"
-    template = f"""<html>
-    <head>
+    header = f"""<!doctype html>
+<html lang="en">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"><html>
     <link href="{rel_root_path}assets/markdown.css" rel="stylesheet" />
-    </head>
-    <body>
+</head>
+<body>
     """
+    footer = """</body>
+</html>"""
     with open(input, "r") as input_file:
-        html = template + markdown.markdown(input_file.read()) + "</body></html>"
+        html = header + markdown.markdown(
+            input_file.read(), 
+            extensions=['tables','md_in_html']
+            ) + footer
         with open(output, "w") as output_file:
             output_file.write(html)
 


### PR DESCRIPTION
Added deprecation dates for V2 (1 Apr 2026)
Release plan now included on docs.carbon-transparency.org
Links fixed in v3/FAQ 
