### PR TITLE
ADR-49 ensure support future multi version API

### DIFF
--- a/decisions/log/0049-hotfix-for-future-support-multiple-versions.md
+++ b/decisions/log/0049-hotfix-for-future-support-multiple-versions.md
@@ -1,4 +1,4 @@
-# 49. Hotfix to include in 3.0 for future support for multiple versions
+# 49. Mandatory specVersion parameter to support future multiple versions
 
 Date: 2025-05-20
 


### PR DESCRIPTION
ADR 0048 proposes a way of supporting multiple versions of the product carbon footprint (PCF) data model over 3.0 API. In effect this would mean splitting the version of the API and the version of the data model.

Because of tight timelines we cannot include this in version 3.0 of the standard yet. We as PACT feel that, because of the added complexity it brings, it needs more reasoning, more reference cases to other architecture and more feedback from software solution providers implementing real-world data exchange.

In order to make future realization of ADR 0048 possible without requring us to wait for a new backwards incompatible version 4.0, we can include ADR 0049: adding a mandatory `specVersion` parameter, which is fixed to specVersion=3. This will enable us to introduce a multi-version API as a minor release (3.x) because it will not break backwards compatibility with existing 3.0 APIs.

Alternatives are:
 - Introduce this in 4.0
 - Rely on current (most common) versioning approach: support multiple versions by implementing multiple versions of the API: 
   - `pcf.exchange.com/pact/2/...`
   - `pcf.exchange.com/pact/3/...`